### PR TITLE
Fix Dockerfile path for index service

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && \
         langdetect \
         pefile
 
-COPY index_worker.py .
+COPY index_service.py .
 COPY ../MyLogger.py .
 
-CMD ["python", "index_worker.py"]
+CMD ["python", "index_service.py"]
 


### PR DESCRIPTION
## Summary
- copy the new `index_service.py` in the indexer Dockerfile
- update CMD to run `index_service.py`

## Testing
- `docker compose build` *(fails: `docker` command not found)*