### PR TITLE
Create LLM backend abstraction for multiple providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,57 @@
+# LLM Provider Configuration Example
+# Copy this file to .env and configure your preferred provider(s)
+
+# ============================================
+# Provider Selection
+# ============================================
+# Specify which provider to use explicitly (optional)
+# If not set, will auto-select based on available API keys
+# Options: openai, anthropic, ollama
+# LLM_PROVIDER=openai
+
+# Provider preference order (comma-separated)
+# Will try each provider in order until one succeeds
+LLM_PROVIDER_PREFERENCE=openai,anthropic,ollama
+
+# ============================================
+# OpenAI Configuration
+# ============================================
+# Get your API key from: https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+
+# ============================================
+# Anthropic Configuration
+# ============================================
+# Get your API key from: https://console.anthropic.com/
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+ANTHROPIC_MODEL=claude-3-5-haiku-20241022
+
+# Note: Anthropic does not provide embeddings.
+# For embeddings, use OpenAI or Ollama.
+
+# ============================================
+# Ollama Configuration (Local Models)
+# ============================================
+# Ollama runs models locally, no API key needed
+# Install Ollama from: https://ollama.ai/
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3.2
+OLLAMA_EMBEDDING_MODEL=nomic-embed-text
+
+# ============================================
+# General LLM Settings
+# ============================================
+LLM_TIMEOUT=60
+LLM_MAX_RETRIES=3
+
+# Enable embedding generation (requires OpenAI or Ollama)
+ENABLE_EMBEDDINGS=false
+
+# ============================================
+# Index Worker Settings
+# ============================================
+DATABASE_URI=sqlite:///instance/files.db
+NUM_WORKERS=4
+POLL_INTERVAL=2

--- a/indexer/index_worker.py
+++ b/indexer/index_worker.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+Modernized Index Worker using LLM Provider Abstraction
+
+This worker processes files from the index queue using configurable LLM providers
+(OpenAI, Anthropic, or Ollama) for document analysis and categorization.
+"""
+
+import os
+import sys
+import time
+import threading
+import logging
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.exc import SQLAlchemyError
+from langdetect import detect
+from langdetect.lang_detect_exception import LangDetectException
+from tika import parser
+import magic
+import pefile
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from MyLogger import Logger
+from llm_providers import get_llm_provider
+from llm_providers.factory import ProviderConfig, list_available_providers
+
+# ---------- Configuration ----------
+DATABASE_URI = os.getenv('DATABASE_URI', 'sqlite:///instance/files.db')
+NUM_WORKERS = int(os.getenv('NUM_WORKERS', '4'))
+POLL_INTERVAL = int(os.getenv('POLL_INTERVAL', '2'))  # seconds
+
+# LLM Provider Configuration
+LLM_PROVIDER = os.getenv('LLM_PROVIDER')  # Optional: specify provider explicitly
+ENABLE_EMBEDDINGS = os.getenv('ENABLE_EMBEDDINGS', 'false').lower() == 'true'
+
+# ---------- Logger Setup ----------
+log = Logger(log_name='index_worker_llm', log_level=logging.DEBUG).get_logger()
+
+# ---------- SQLAlchemy Setup ----------
+Base = declarative_base()
+engine = create_engine(DATABASE_URI)
+Session = sessionmaker(bind=engine)
+
+# ---------- Models ----------
+class FileMetadata(Base):
+    __tablename__ = 'file_metadata'
+    from sqlalchemy import Column, Integer, String, Float, Text
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    path = Column(String, unique=True, nullable=False)
+    size = Column(Integer, nullable=False)
+    modification_date = Column(Float, nullable=False)
+    category = Column(String)
+    inferred_category = Column(String)
+    keywords = Column(String)
+    summary = Column(String)
+    content = Column(Text)
+    file_type = Column(String)
+    creator_software = Column(String)
+    origin_date = Column(String)
+    pe_info = Column(Text)
+    # New fields for LLM tracking
+    llm_provider = Column(String)
+    llm_model = Column(String)
+    embedding_vector = Column(Text)  # JSON-encoded vector
+
+
+class IndexQueue(Base):
+    __tablename__ = 'index_queue'
+    from sqlalchemy import Column, Integer, String, Float, Text
+    id = Column(Integer, primary_key=True)
+    file_path = Column(String, unique=True, nullable=False)
+    status = Column(String, default='pending')  # pending, in_progress, done, error
+    error = Column(Text, nullable=True)
+    added_at = Column(Float)
+    started_at = Column(Float)
+    finished_at = Column(Float)
+
+
+# ---------- Helper Functions ----------
+def detect_file_type(file_path):
+    """Detect MIME type and file type using magic"""
+    file_magic = magic.Magic(mime=True)
+    mime_type = file_magic.from_file(file_path)
+    parts = mime_type.split('/')
+    file_type = parts[0]
+    creator_software = parts[1] if len(parts) > 1 else 'Unknown'
+    return mime_type, file_type, creator_software
+
+
+def get_pe_info(file_path):
+    """Extract PE (Windows executable) information"""
+    try:
+        pe = pefile.PE(file_path)
+        return str({
+            "entry_point": pe.OPTIONAL_HEADER.AddressOfEntryPoint,
+            "image_base": pe.OPTIONAL_HEADER.ImageBase,
+            "number_of_sections": pe.FILE_HEADER.NumberOfSections
+        })
+    except Exception as e:
+        return str(e)
+
+
+def clean_text(text):
+    """Clean and normalize text content"""
+    import re
+    text = re.sub(r'\n+', '\n', text)
+    text = text.strip()
+    return re.sub(r'\s+', ' ', text)
+
+
+# ---------- Indexing Worker Thread ----------
+class IndexWorker(threading.Thread):
+    """Worker thread that processes files from the index queue"""
+
+    def __init__(self, worker_id, llm_provider):
+        """
+        Initialize worker
+
+        Args:
+            worker_id: Unique worker identifier
+            llm_provider: LLM provider instance
+        """
+        super().__init__()
+        self.worker_id = worker_id
+        self.running = True
+        self.llm_provider = llm_provider
+        log.info(f"Worker-{worker_id} initialized with provider: {llm_provider.get_provider_name()}")
+
+    def run(self):
+        """Main worker loop"""
+        log.info(f"Worker-{self.worker_id} started.")
+
+        while self.running:
+            with Session() as session:
+                # Get next pending job
+                job = session.execute(
+                    select(IndexQueue)
+                    .where(IndexQueue.status == 'pending')
+                    .limit(1)
+                ).scalar_one_or_none()
+
+                if not job:
+                    time.sleep(POLL_INTERVAL)
+                    continue
+
+                log.debug(f"Worker-{self.worker_id} processing {job.file_path}")
+                job.status = 'in_progress'
+                job.started_at = time.time()
+                session.commit()
+
+                try:
+                    self.process_file(session, job)
+                    job.status = 'done'
+                    job.finished_at = time.time()
+                    session.commit()
+                    log.info(f"Worker-{self.worker_id} indexed {job.file_path}")
+                except Exception as e:
+                    job.status = 'error'
+                    job.error = str(e)
+                    job.finished_at = time.time()
+                    session.commit()
+                    log.error(f"Worker-{self.worker_id} failed on {job.file_path}: {e}")
+
+    def process_file(self, session, job):
+        """
+        Process a single file using the LLM provider
+
+        Args:
+            session: SQLAlchemy session
+            job: IndexQueue job record
+        """
+        path = job.file_path
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"File does not exist: {path}")
+
+        size = os.path.getsize(path)
+        mod_time = os.path.getmtime(path)
+        origin_date = str(mod_time)
+        mime_type, file_type, creator_software = detect_file_type(path)
+        category = os.path.basename(os.path.dirname(path))
+        pe_info = ""
+        content = ""
+        inferred_category = None
+        keywords = None
+        summary = None
+        embedding_vector = None
+
+        ext = os.path.splitext(path)[1].lower()
+
+        # Process based on file type
+        if ext == ".exe":
+            pe_info = get_pe_info(path)
+            content = pe_info
+            inferred_category = "Executable"
+
+        elif ext in [".pdf", ".doc", ".docx", ".txt"]:
+            # Extract text content
+            if ext == ".txt":
+                try:
+                    with open(path, 'r', encoding='utf-8') as f:
+                        content = f.read()
+                except Exception as e:
+                    log.warning(f"Failed to read text file {path}: {e}")
+                    content = ""
+            else:
+                parsed = parser.from_file(path)
+                content = parsed.get("content", "") if parsed else ""
+
+            content = clean_text(content)
+
+            if content:
+                # Detect language
+                try:
+                    lang = detect(content[:500])
+                except LangDetectException:
+                    lang = "unknown"
+
+                # Use LLM provider for inference
+                try:
+                    response = self.llm_provider.infer_category_and_keywords(
+                        content=content[:1000],  # Use first 1000 chars
+                        language=lang,
+                        file_path=path
+                    )
+
+                    inferred_category = response.category
+                    keywords = response.keywords
+                    summary = response.summary
+
+                    log.debug(f"LLM inference successful for {path}: category={inferred_category}")
+
+                    # Generate embeddings if enabled
+                    if ENABLE_EMBEDDINGS:
+                        try:
+                            emb_response = self.llm_provider.generate_embedding(content[:8000])
+                            # Store as JSON string
+                            import json
+                            embedding_vector = json.dumps(emb_response.embedding)
+                            log.debug(f"Generated embedding for {path} (dim={len(emb_response.embedding)})")
+                        except NotImplementedError:
+                            log.debug(f"Embeddings not supported by {self.llm_provider.get_provider_name()}")
+                        except Exception as e:
+                            log.warning(f"Failed to generate embedding for {path}: {e}")
+
+                except Exception as e:
+                    log.error(f"LLM inference failed for {path}: {e}")
+                    # Continue with partial metadata
+
+        else:
+            # Other file types - just extract content
+            parsed = parser.from_file(path)
+            content = parsed.get("content", "") if parsed else ""
+            content = clean_text(content)
+
+        # Create or update metadata
+        metadata = FileMetadata(
+            path=path,
+            size=size,
+            modification_date=mod_time,
+            category=category,
+            inferred_category=inferred_category,
+            keywords=keywords,
+            summary=summary,
+            content=summary if summary else content[:5000],  # Store summary or truncated content
+            file_type=file_type,
+            creator_software=creator_software,
+            origin_date=origin_date,
+            pe_info=pe_info,
+            llm_provider=self.llm_provider.get_provider_name(),
+            llm_model=self.llm_provider.model,
+            embedding_vector=embedding_vector
+        )
+        session.merge(metadata)
+
+
+# ---------- Entrypoint ----------
+def main():
+    """Main entry point for the index worker"""
+    log.info("=" * 60)
+    log.info("Starting Index Worker with LLM Provider Abstraction")
+    log.info("=" * 60)
+
+    # Initialize provider configuration
+    provider_config = ProviderConfig()
+
+    # Log available providers
+    available = list_available_providers(provider_config)
+    log.info(f"Available providers: {available}")
+
+    # Get LLM provider
+    try:
+        llm_provider = get_llm_provider(provider_name=LLM_PROVIDER, config=provider_config)
+        log.info(f"Using LLM provider: {llm_provider.get_provider_name()}")
+        log.info(f"Model: {llm_provider.model}")
+        log.info(f"Embeddings enabled: {ENABLE_EMBEDDINGS}")
+    except Exception as e:
+        log.error(f"Failed to initialize LLM provider: {e}")
+        log.error("Please configure at least one provider:")
+        log.error("  - Set OPENAI_API_KEY for OpenAI")
+        log.error("  - Set ANTHROPIC_API_KEY for Anthropic")
+        log.error("  - Ensure Ollama is running at OLLAMA_BASE_URL")
+        sys.exit(1)
+
+    # Create database tables
+    Base.metadata.create_all(engine)
+
+    # Start workers
+    log.info(f"Starting {NUM_WORKERS} worker threads...")
+    workers = [IndexWorker(i, llm_provider) for i in range(NUM_WORKERS)]
+    for w in workers:
+        w.start()
+
+    log.info("Index worker service is running. Press Ctrl+C to stop.")
+
+    # Main loop
+    try:
+        while True:
+            time.sleep(5)
+    except KeyboardInterrupt:
+        log.info("Stopping all workers...")
+        for w in workers:
+            w.running = False
+        for w in workers:
+            w.join()
+        log.info("Index worker service stopped.")
+
+
+if __name__ == '__main__':
+    main()

--- a/llm_providers/README.md
+++ b/llm_providers/README.md
@@ -1,0 +1,289 @@
+# LLM Provider Abstraction Layer
+
+This module provides a unified interface for interacting with multiple LLM providers (OpenAI, Anthropic, Ollama) for document indexing and analysis.
+
+## Features
+
+- **Multi-Provider Support**: Switch between OpenAI, Anthropic, and Ollama
+- **Token-Key Based Selection**: Automatically selects provider based on available API keys
+- **Fallback Support**: Gracefully falls back to alternative providers if primary fails
+- **Unified Interface**: Common API across all providers
+- **Embeddings Support**: Generate embeddings with OpenAI or Ollama
+- **Configuration-Driven**: Flexible configuration via environment variables
+
+## Architecture
+
+```
+llm_providers/
+├── __init__.py           # Package initialization
+├── base.py              # Abstract base class
+├── openai_provider.py   # OpenAI implementation
+├── anthropic_provider.py # Anthropic implementation
+├── ollama_provider.py   # Ollama implementation
+└── factory.py           # Provider factory with auto-selection
+```
+
+## Providers
+
+### OpenAI
+- **Models**: GPT-4o-mini (default), GPT-4, GPT-3.5
+- **Embeddings**: text-embedding-3-small (default)
+- **Requires**: API key from https://platform.openai.com/
+- **Best for**: High-quality inference and embeddings
+
+### Anthropic (Claude)
+- **Models**: Claude 3.5 Haiku (default), Claude 3 Opus, Claude 3 Sonnet
+- **Embeddings**: Not supported (use OpenAI or Ollama)
+- **Requires**: API key from https://console.anthropic.com/
+- **Best for**: High-quality inference with strong reasoning
+
+### Ollama
+- **Models**: Llama 3.2 (default), Mistral, many others
+- **Embeddings**: nomic-embed-text (default)
+- **Requires**: Local Ollama installation from https://ollama.ai/
+- **Best for**: Local/offline processing, privacy-sensitive data
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Configure Provider
+
+Copy the example environment file and configure your preferred provider:
+
+```bash
+cp .env.example .env
+# Edit .env with your API keys
+```
+
+For OpenAI:
+```bash
+export OPENAI_API_KEY="your-api-key-here"
+```
+
+For Anthropic:
+```bash
+export ANTHROPIC_API_KEY="your-api-key-here"
+```
+
+For Ollama (local):
+```bash
+# Install Ollama from https://ollama.ai/
+ollama pull llama3.2
+ollama pull nomic-embed-text
+ollama serve
+```
+
+### 3. Use in Code
+
+```python
+from llm_providers import get_llm_provider
+
+# Auto-select provider based on configuration
+provider = get_llm_provider()
+
+# Or specify explicitly
+provider = get_llm_provider(provider_name='openai')
+
+# Infer category, keywords, and summary
+response = provider.infer_category_and_keywords(
+    content="Your document content here",
+    language="en",
+    file_path="/path/to/document.pdf"
+)
+
+print(f"Category: {response.category}")
+print(f"Keywords: {response.keywords}")
+print(f"Summary: {response.summary}")
+
+# Generate embeddings (OpenAI or Ollama only)
+embedding_response = provider.generate_embedding("Content to embed")
+print(f"Embedding dimensions: {len(embedding_response.embedding)}")
+
+# Generic chat completion
+messages = [
+    {"role": "user", "content": "Hello!"}
+]
+response_text = provider.chat_completion(messages)
+print(response_text)
+```
+
+## Running the Index Worker
+
+The modernized index worker uses the LLM provider abstraction:
+
+```bash
+# Using default provider (auto-selected)
+python indexer/index_worker.py
+
+# Using specific provider
+LLM_PROVIDER=openai python indexer/index_worker.py
+
+# With embeddings enabled
+ENABLE_EMBEDDINGS=true python indexer/index_worker.py
+
+# Using Ollama (local)
+LLM_PROVIDER=ollama python indexer/index_worker.py
+```
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LLM_PROVIDER` | Explicit provider selection | Auto-detect |
+| `LLM_PROVIDER_PREFERENCE` | Fallback order | `openai,anthropic,ollama` |
+| `OPENAI_API_KEY` | OpenAI API key | - |
+| `OPENAI_MODEL` | OpenAI model name | `gpt-4o-mini` |
+| `OPENAI_EMBEDDING_MODEL` | OpenAI embedding model | `text-embedding-3-small` |
+| `ANTHROPIC_API_KEY` | Anthropic API key | - |
+| `ANTHROPIC_MODEL` | Anthropic model name | `claude-3-5-haiku-20241022` |
+| `OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434` |
+| `OLLAMA_MODEL` | Ollama model name | `llama3.2` |
+| `OLLAMA_EMBEDDING_MODEL` | Ollama embedding model | `nomic-embed-text` |
+| `LLM_TIMEOUT` | Request timeout (seconds) | `60` |
+| `LLM_MAX_RETRIES` | Max retry attempts | `3` |
+| `ENABLE_EMBEDDINGS` | Enable embedding generation | `false` |
+
+## Provider Selection Logic
+
+The factory uses the following logic to select a provider:
+
+1. If `LLM_PROVIDER` is set explicitly, use that provider
+2. Otherwise, check providers in `LLM_PROVIDER_PREFERENCE` order
+3. For each provider, verify:
+   - API keys are configured (OpenAI, Anthropic)
+   - Service is reachable (Ollama)
+   - Connection test succeeds
+4. Use the first working provider
+5. Fall back to next provider if current one fails
+
+## API Reference
+
+### BaseLLMProvider
+
+Abstract base class that all providers implement.
+
+#### Methods
+
+- `infer_category_and_keywords(content, language, file_path)` → `LLMResponse`
+  - Analyze content and extract category, keywords, and summary
+
+- `generate_embedding(content)` → `EmbeddingResponse`
+  - Generate embedding vector for content
+
+- `chat_completion(messages, temperature, max_tokens)` → `str`
+  - Generic chat completion
+
+- `test_connection()` → `bool`
+  - Test if provider is available
+
+### Response Types
+
+#### LLMResponse
+```python
+@dataclass
+class LLMResponse:
+    category: Optional[str]
+    keywords: Optional[str]
+    summary: Optional[str]
+    raw_response: Optional[str]
+    metadata: Optional[Dict[str, Any]]
+```
+
+#### EmbeddingResponse
+```python
+@dataclass
+class EmbeddingResponse:
+    embedding: List[float]
+    model: str
+    metadata: Optional[Dict[str, Any]]
+```
+
+## Migration from Old System
+
+The old `inference_server.py` can be replaced with this abstraction:
+
+### Before (Old System)
+```python
+response = requests.post(INFERENCE_URL, json={
+    "content": content,
+    "language": lang
+})
+result = response.json()
+```
+
+### After (New System)
+```python
+from llm_providers import get_llm_provider
+
+provider = get_llm_provider()
+response = provider.infer_category_and_keywords(
+    content=content,
+    language=lang
+)
+```
+
+## Troubleshooting
+
+### OpenAI Connection Fails
+- Verify API key is correct: `echo $OPENAI_API_KEY`
+- Check API quota and billing: https://platform.openai.com/usage
+- Ensure network connectivity to api.openai.com
+
+### Anthropic Connection Fails
+- Verify API key is correct: `echo $ANTHROPIC_API_KEY`
+- Check API quota: https://console.anthropic.com/
+- Ensure network connectivity to api.anthropic.com
+
+### Ollama Connection Fails
+- Verify Ollama is running: `ollama list`
+- Check server is accessible: `curl http://localhost:11434/api/tags`
+- Pull required models:
+  ```bash
+  ollama pull llama3.2
+  ollama pull nomic-embed-text
+  ```
+
+### "No LLM provider available" Error
+- At least one provider must be configured
+- Set API key environment variable or run Ollama locally
+- Check provider configuration with:
+  ```python
+  from llm_providers.factory import list_available_providers
+  print(list_available_providers())
+  ```
+
+## Performance Considerations
+
+- **OpenAI**: Fast, cloud-based, metered billing
+- **Anthropic**: Fast, cloud-based, metered billing
+- **Ollama**: Slower (depends on hardware), local, free
+
+For production use:
+- Use OpenAI/Anthropic for speed and quality
+- Use Ollama for sensitive data or offline scenarios
+- Enable fallback for high availability
+- Consider rate limits and adjust `NUM_WORKERS` accordingly
+
+## Security Notes
+
+- **API Keys**: Never commit API keys to version control
+- **Sensitive Data**: Use Ollama for PII or confidential documents
+- **Local Processing**: Ollama processes everything locally
+- **Cloud Processing**: OpenAI/Anthropic send data to their APIs
+
+## Future Enhancements
+
+- [ ] Add support for Azure OpenAI
+- [ ] Add support for Google Gemini
+- [ ] Implement request queuing and rate limiting
+- [ ] Add response caching
+- [ ] Structured output validation
+- [ ] Batch processing optimization
+- [ ] Vector database integration for embeddings

--- a/llm_providers/__init__.py
+++ b/llm_providers/__init__.py
@@ -1,0 +1,6 @@
+"""LLM Provider Abstraction Layer"""
+
+from .base import BaseLLMProvider
+from .factory import get_llm_provider
+
+__all__ = ['BaseLLMProvider', 'get_llm_provider']

--- a/llm_providers/anthropic_provider.py
+++ b/llm_providers/anthropic_provider.py
@@ -1,0 +1,207 @@
+"""Anthropic Claude LLM Provider Implementation"""
+
+import logging
+from typing import Dict, List, Optional
+from .base import BaseLLMProvider, LLMResponse, EmbeddingResponse
+
+try:
+    from anthropic import Anthropic
+except ImportError:
+    Anthropic = None
+
+log = logging.getLogger(__name__)
+
+
+class AnthropicProvider(BaseLLMProvider):
+    """Anthropic Claude API provider implementation"""
+
+    def __init__(self, api_key: str, model: str = "claude-3-5-haiku-20241022", **kwargs):
+        """
+        Initialize Anthropic provider
+
+        Args:
+            api_key: Anthropic API key
+            model: Model to use (default: claude-3-5-haiku-20241022)
+            **kwargs: Additional configuration
+        """
+        super().__init__(api_key, model, **kwargs)
+
+        if Anthropic is None:
+            raise ImportError("anthropic package is not installed. Install with: pip install anthropic")
+
+        self.client = Anthropic(api_key=api_key)
+        self.timeout = kwargs.get('timeout', 30)
+        self.max_retries = kwargs.get('max_retries', 3)
+
+    def infer_category_and_keywords(
+        self,
+        content: str,
+        language: str = 'en',
+        file_path: Optional[str] = None
+    ) -> LLMResponse:
+        """
+        Use Claude to infer category, extract keywords, and generate summary
+
+        Args:
+            content: Text content to analyze
+            language: Language of the content
+            file_path: Optional file path for context
+
+        Returns:
+            LLMResponse with category, keywords, and summary
+        """
+        try:
+            prompt = self._build_inference_prompt(content, language, file_path)
+
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=500,
+                temperature=0.3,
+                system="You are a document analysis assistant. Analyze the provided content and extract structured information.",
+                messages=[
+                    {"role": "user", "content": prompt}
+                ],
+                timeout=self.timeout
+            )
+
+            result_text = response.content[0].text
+            parsed = self._parse_inference_response(result_text)
+
+            return LLMResponse(
+                category=parsed.get('category'),
+                keywords=parsed.get('keywords'),
+                summary=parsed.get('summary'),
+                raw_response=result_text,
+                metadata={
+                    'model': self.model,
+                    'provider': 'anthropic',
+                    'input_tokens': response.usage.input_tokens if hasattr(response, 'usage') else None,
+                    'output_tokens': response.usage.output_tokens if hasattr(response, 'usage') else None
+                }
+            )
+
+        except Exception as e:
+            log.error(f"Anthropic inference failed: {e}")
+            raise
+
+    def generate_embedding(self, content: str) -> EmbeddingResponse:
+        """
+        Generate embeddings - Note: Anthropic doesn't provide native embeddings
+
+        This will raise NotImplementedError. For embeddings with Anthropic,
+        consider using a separate embedding provider like Voyage AI or OpenAI.
+
+        Args:
+            content: Text content to embed
+
+        Returns:
+            EmbeddingResponse with embedding vector
+        """
+        raise NotImplementedError(
+            "Anthropic does not provide native embedding endpoints. "
+            "Use OpenAI or Ollama for embeddings, or integrate a dedicated embedding service like Voyage AI."
+        )
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None
+    ) -> str:
+        """
+        Generic chat completion using Claude
+
+        Args:
+            messages: List of message dictionaries
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+
+        Returns:
+            Response text
+        """
+        try:
+            # Extract system message if present
+            system_msg = None
+            user_messages = []
+
+            for msg in messages:
+                if msg['role'] == 'system':
+                    system_msg = msg['content']
+                else:
+                    user_messages.append(msg)
+
+            kwargs = {
+                'model': self.model,
+                'messages': user_messages,
+                'temperature': temperature,
+                'timeout': self.timeout
+            }
+
+            if system_msg:
+                kwargs['system'] = system_msg
+
+            if max_tokens:
+                kwargs['max_tokens'] = max_tokens
+            else:
+                kwargs['max_tokens'] = 1024
+
+            response = self.client.messages.create(**kwargs)
+
+            return response.content[0].text
+
+        except Exception as e:
+            log.error(f"Anthropic chat completion failed: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test Anthropic connection
+
+        Returns:
+            True if connection is successful
+        """
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=5,
+                messages=[{"role": "user", "content": "test"}],
+                timeout=10
+            )
+            return response.content[0].text is not None
+
+        except Exception as e:
+            log.error(f"Anthropic connection test failed: {e}")
+            return False
+
+    def _build_inference_prompt(self, content: str, language: str, file_path: Optional[str] = None) -> str:
+        """Build the prompt for inference"""
+        context = f"File: {file_path}\n" if file_path else ""
+        return f"""{context}Language: {language}
+
+Analyze the following document content and provide:
+1. Category (one word or short phrase describing the document type/topic)
+2. Keywords (comma-separated list of 5-10 important keywords)
+3. Summary (2-3 sentence summary of the content)
+
+Content:
+{content[:1000]}
+
+Respond in this format:
+Category: [category]
+Keywords: [keyword1, keyword2, ...]
+Summary: [summary]"""
+
+    def _parse_inference_response(self, response: str) -> Dict[str, str]:
+        """Parse the structured response from Claude"""
+        result = {}
+        lines = response.strip().split('\n')
+
+        for line in lines:
+            if line.startswith('Category:'):
+                result['category'] = line.replace('Category:', '').strip()
+            elif line.startswith('Keywords:'):
+                result['keywords'] = line.replace('Keywords:', '').strip()
+            elif line.startswith('Summary:'):
+                result['summary'] = line.replace('Summary:', '').strip()
+
+        return result

--- a/llm_providers/base.py
+++ b/llm_providers/base.py
@@ -1,0 +1,107 @@
+"""Base LLM Provider Abstract Class"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
+
+
+@dataclass
+class LLMResponse:
+    """Standard response format for LLM operations"""
+    category: Optional[str] = None
+    keywords: Optional[str] = None
+    summary: Optional[str] = None
+    raw_response: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class EmbeddingResponse:
+    """Standard response format for embedding operations"""
+    embedding: List[float]
+    model: str
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class BaseLLMProvider(ABC):
+    """Abstract base class for LLM providers"""
+
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None, **kwargs):
+        """
+        Initialize the LLM provider
+
+        Args:
+            api_key: API key for the provider (optional for local models like Ollama)
+            model: Model name to use
+            **kwargs: Additional provider-specific configuration
+        """
+        self.api_key = api_key
+        self.model = model
+        self.config = kwargs
+
+    @abstractmethod
+    def infer_category_and_keywords(
+        self,
+        content: str,
+        language: str = 'en',
+        file_path: Optional[str] = None
+    ) -> LLMResponse:
+        """
+        Infer category, extract keywords, and generate summary from content
+
+        Args:
+            content: Text content to analyze
+            language: Language of the content
+            file_path: Optional file path for context
+
+        Returns:
+            LLMResponse with category, keywords, and summary
+        """
+        pass
+
+    @abstractmethod
+    def generate_embedding(self, content: str) -> EmbeddingResponse:
+        """
+        Generate embeddings for the given content
+
+        Args:
+            content: Text content to embed
+
+        Returns:
+            EmbeddingResponse with embedding vector
+        """
+        pass
+
+    @abstractmethod
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None
+    ) -> str:
+        """
+        Generic chat completion interface
+
+        Args:
+            messages: List of message dictionaries with 'role' and 'content'
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+
+        Returns:
+            Response text
+        """
+        pass
+
+    @abstractmethod
+    def test_connection(self) -> bool:
+        """
+        Test if the provider is available and properly configured
+
+        Returns:
+            True if connection is successful, False otherwise
+        """
+        pass
+
+    def get_provider_name(self) -> str:
+        """Get the name of this provider"""
+        return self.__class__.__name__.replace('Provider', '')

--- a/llm_providers/factory.py
+++ b/llm_providers/factory.py
@@ -1,0 +1,200 @@
+"""LLM Provider Factory - Token-key based provider selection"""
+
+import os
+import logging
+from typing import Optional, Dict, Any
+from .base import BaseLLMProvider
+from .openai_provider import OpenAIProvider
+from .anthropic_provider import AnthropicProvider
+from .ollama_provider import OllamaProvider
+
+log = logging.getLogger(__name__)
+
+
+class ProviderConfig:
+    """Configuration for LLM providers"""
+
+    def __init__(self, config_dict: Optional[Dict[str, Any]] = None):
+        """
+        Initialize provider configuration
+
+        Args:
+            config_dict: Optional configuration dictionary
+        """
+        if config_dict is None:
+            config_dict = {}
+
+        # Provider selection priority
+        self.openai_api_key = config_dict.get('openai_api_key') or os.getenv('OPENAI_API_KEY')
+        self.anthropic_api_key = config_dict.get('anthropic_api_key') or os.getenv('ANTHROPIC_API_KEY')
+        self.ollama_base_url = config_dict.get('ollama_base_url') or os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434')
+
+        # Model configurations
+        self.openai_model = config_dict.get('openai_model') or os.getenv('OPENAI_MODEL', 'gpt-4o-mini')
+        self.openai_embedding_model = config_dict.get('openai_embedding_model') or os.getenv('OPENAI_EMBEDDING_MODEL', 'text-embedding-3-small')
+
+        self.anthropic_model = config_dict.get('anthropic_model') or os.getenv('ANTHROPIC_MODEL', 'claude-3-5-haiku-20241022')
+
+        self.ollama_model = config_dict.get('ollama_model') or os.getenv('OLLAMA_MODEL', 'llama3.2')
+        self.ollama_embedding_model = config_dict.get('ollama_embedding_model') or os.getenv('OLLAMA_EMBEDDING_MODEL', 'nomic-embed-text')
+
+        # Provider preference order (can be overridden)
+        self.provider_preference = config_dict.get('provider_preference') or os.getenv('LLM_PROVIDER_PREFERENCE', 'openai,anthropic,ollama')
+
+        # Additional options
+        self.timeout = int(config_dict.get('timeout') or os.getenv('LLM_TIMEOUT', '60'))
+        self.max_retries = int(config_dict.get('max_retries') or os.getenv('LLM_MAX_RETRIES', '3'))
+
+        # Fallback behavior
+        self.enable_fallback = config_dict.get('enable_fallback', True)
+
+
+def get_llm_provider(
+    provider_name: Optional[str] = None,
+    config: Optional[ProviderConfig] = None,
+    **kwargs
+) -> BaseLLMProvider:
+    """
+    Factory function to get the appropriate LLM provider based on token-key settings
+
+    Selection logic:
+    1. If provider_name is specified, use that provider
+    2. Otherwise, check for API keys in order of preference
+    3. Fall back to next available provider if preferred one fails
+
+    Args:
+        provider_name: Explicit provider name ('openai', 'anthropic', 'ollama')
+        config: ProviderConfig instance (will create default if not provided)
+        **kwargs: Additional provider-specific configuration
+
+    Returns:
+        Configured LLM provider instance
+
+    Raises:
+        ValueError: If no provider is available or configured
+    """
+    if config is None:
+        config = ProviderConfig()
+
+    # If explicit provider requested, return that
+    if provider_name:
+        return _create_provider(provider_name, config, **kwargs)
+
+    # Otherwise, try providers in preference order
+    preference_order = [p.strip().lower() for p in config.provider_preference.split(',')]
+
+    for provider in preference_order:
+        try:
+            instance = _create_provider(provider, config, **kwargs)
+
+            # Test connection if fallback is enabled
+            if config.enable_fallback:
+                if instance.test_connection():
+                    log.info(f"Successfully initialized {provider} provider")
+                    return instance
+                else:
+                    log.warning(f"{provider} provider failed connection test, trying next provider")
+                    continue
+            else:
+                return instance
+
+        except Exception as e:
+            log.warning(f"Failed to initialize {provider} provider: {e}")
+            if not config.enable_fallback:
+                raise
+            continue
+
+    raise ValueError(
+        "No LLM provider available. Please configure at least one provider:\n"
+        "- Set OPENAI_API_KEY for OpenAI\n"
+        "- Set ANTHROPIC_API_KEY for Anthropic\n"
+        "- Ensure Ollama is running at OLLAMA_BASE_URL"
+    )
+
+
+def _create_provider(provider_name: str, config: ProviderConfig, **kwargs) -> BaseLLMProvider:
+    """
+    Create a specific provider instance
+
+    Args:
+        provider_name: Name of the provider ('openai', 'anthropic', 'ollama')
+        config: ProviderConfig instance
+        **kwargs: Additional provider-specific configuration
+
+    Returns:
+        Configured provider instance
+
+    Raises:
+        ValueError: If provider name is invalid or configuration is missing
+    """
+    provider_name = provider_name.lower().strip()
+
+    # Merge config with kwargs
+    merged_kwargs = {
+        'timeout': config.timeout,
+        'max_retries': config.max_retries,
+        **kwargs
+    }
+
+    if provider_name == 'openai':
+        if not config.openai_api_key:
+            raise ValueError("OpenAI API key not configured. Set OPENAI_API_KEY environment variable.")
+
+        return OpenAIProvider(
+            api_key=config.openai_api_key,
+            model=config.openai_model,
+            embedding_model=config.openai_embedding_model,
+            **merged_kwargs
+        )
+
+    elif provider_name == 'anthropic':
+        if not config.anthropic_api_key:
+            raise ValueError("Anthropic API key not configured. Set ANTHROPIC_API_KEY environment variable.")
+
+        return AnthropicProvider(
+            api_key=config.anthropic_api_key,
+            model=config.anthropic_model,
+            **merged_kwargs
+        )
+
+    elif provider_name == 'ollama':
+        return OllamaProvider(
+            base_url=config.ollama_base_url,
+            model=config.ollama_model,
+            embedding_model=config.ollama_embedding_model,
+            **merged_kwargs
+        )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider_name}. Choose from: openai, anthropic, ollama")
+
+
+def list_available_providers(config: Optional[ProviderConfig] = None) -> Dict[str, bool]:
+    """
+    Check which providers are available based on configuration
+
+    Args:
+        config: ProviderConfig instance (will create default if not provided)
+
+    Returns:
+        Dictionary mapping provider names to availability status
+    """
+    if config is None:
+        config = ProviderConfig()
+
+    availability = {}
+
+    # Check OpenAI
+    availability['openai'] = bool(config.openai_api_key)
+
+    # Check Anthropic
+    availability['anthropic'] = bool(config.anthropic_api_key)
+
+    # Check Ollama (always potentially available if endpoint is reachable)
+    try:
+        ollama = OllamaProvider(base_url=config.ollama_base_url, model=config.ollama_model)
+        availability['ollama'] = ollama.test_connection()
+    except Exception:
+        availability['ollama'] = False
+
+    return availability

--- a/llm_providers/ollama_provider.py
+++ b/llm_providers/ollama_provider.py
@@ -1,0 +1,269 @@
+"""Ollama Local LLM Provider Implementation"""
+
+import logging
+import requests
+from typing import Dict, List, Optional
+from .base import BaseLLMProvider, LLMResponse, EmbeddingResponse
+
+log = logging.getLogger(__name__)
+
+
+class OllamaProvider(BaseLLMProvider):
+    """Ollama local LLM provider implementation"""
+
+    def __init__(self, base_url: str = "http://localhost:11434", model: str = "llama3.2", embedding_model: str = "nomic-embed-text", **kwargs):
+        """
+        Initialize Ollama provider
+
+        Args:
+            base_url: Base URL for Ollama API (default: http://localhost:11434)
+            model: Model to use for chat completions (default: llama3.2)
+            embedding_model: Model to use for embeddings (default: nomic-embed-text)
+            **kwargs: Additional configuration
+        """
+        super().__init__(api_key=None, model=model, **kwargs)
+
+        self.base_url = base_url.rstrip('/')
+        self.embedding_model = embedding_model
+        self.timeout = kwargs.get('timeout', 60)  # Ollama can be slower
+        self.max_retries = kwargs.get('max_retries', 3)
+
+    def infer_category_and_keywords(
+        self,
+        content: str,
+        language: str = 'en',
+        file_path: Optional[str] = None
+    ) -> LLMResponse:
+        """
+        Use Ollama to infer category, extract keywords, and generate summary
+
+        Args:
+            content: Text content to analyze
+            language: Language of the content
+            file_path: Optional file path for context
+
+        Returns:
+            LLMResponse with category, keywords, and summary
+        """
+        try:
+            prompt = self._build_inference_prompt(content, language, file_path)
+
+            response = requests.post(
+                f"{self.base_url}/api/chat",
+                json={
+                    "model": self.model,
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "You are a document analysis assistant. Analyze the provided content and extract structured information."
+                        },
+                        {
+                            "role": "user",
+                            "content": prompt
+                        }
+                    ],
+                    "stream": False,
+                    "options": {
+                        "temperature": 0.3,
+                        "num_predict": 500
+                    }
+                },
+                timeout=self.timeout
+            )
+
+            response.raise_for_status()
+            result_data = response.json()
+            result_text = result_data.get('message', {}).get('content', '')
+
+            parsed = self._parse_inference_response(result_text)
+
+            return LLMResponse(
+                category=parsed.get('category'),
+                keywords=parsed.get('keywords'),
+                summary=parsed.get('summary'),
+                raw_response=result_text,
+                metadata={
+                    'model': self.model,
+                    'provider': 'ollama',
+                    'eval_count': result_data.get('eval_count'),
+                    'prompt_eval_count': result_data.get('prompt_eval_count')
+                }
+            )
+
+        except Exception as e:
+            log.error(f"Ollama inference failed: {e}")
+            raise
+
+    def generate_embedding(self, content: str) -> EmbeddingResponse:
+        """
+        Generate embeddings using Ollama
+
+        Args:
+            content: Text content to embed
+
+        Returns:
+            EmbeddingResponse with embedding vector
+        """
+        try:
+            # Truncate content if too long
+            max_chars = 8000
+            if len(content) > max_chars:
+                content = content[:max_chars]
+
+            response = requests.post(
+                f"{self.base_url}/api/embed",
+                json={
+                    "model": self.embedding_model,
+                    "input": content
+                },
+                timeout=self.timeout
+            )
+
+            response.raise_for_status()
+            result_data = response.json()
+
+            # Ollama returns embeddings in the 'embeddings' field (note: plural)
+            embeddings = result_data.get('embeddings', [])
+            if not embeddings:
+                raise ValueError("No embeddings returned from Ollama")
+
+            return EmbeddingResponse(
+                embedding=embeddings[0],  # First embedding for single input
+                model=self.embedding_model,
+                metadata={
+                    'provider': 'ollama',
+                    'total_duration': result_data.get('total_duration'),
+                    'load_duration': result_data.get('load_duration')
+                }
+            )
+
+        except Exception as e:
+            log.error(f"Ollama embedding failed: {e}")
+            raise
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None
+    ) -> str:
+        """
+        Generic chat completion using Ollama
+
+        Args:
+            messages: List of message dictionaries
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+
+        Returns:
+            Response text
+        """
+        try:
+            options = {
+                "temperature": temperature
+            }
+
+            if max_tokens:
+                options["num_predict"] = max_tokens
+
+            response = requests.post(
+                f"{self.base_url}/api/chat",
+                json={
+                    "model": self.model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": options
+                },
+                timeout=self.timeout
+            )
+
+            response.raise_for_status()
+            result_data = response.json()
+
+            return result_data.get('message', {}).get('content', '')
+
+        except Exception as e:
+            log.error(f"Ollama chat completion failed: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test Ollama connection
+
+        Returns:
+            True if connection is successful
+        """
+        try:
+            response = requests.get(
+                f"{self.base_url}/api/tags",
+                timeout=10
+            )
+            response.raise_for_status()
+
+            # Check if the model is available
+            models = response.json().get('models', [])
+            model_names = [m.get('name', '') for m in models]
+
+            if self.model not in model_names:
+                log.warning(f"Model {self.model} not found in Ollama. Available models: {model_names}")
+                return False
+
+            return True
+
+        except Exception as e:
+            log.error(f"Ollama connection test failed: {e}")
+            return False
+
+    def list_models(self) -> List[str]:
+        """
+        List available models in Ollama
+
+        Returns:
+            List of model names
+        """
+        try:
+            response = requests.get(
+                f"{self.base_url}/api/tags",
+                timeout=10
+            )
+            response.raise_for_status()
+
+            models = response.json().get('models', [])
+            return [m.get('name', '') for m in models]
+
+        except Exception as e:
+            log.error(f"Failed to list Ollama models: {e}")
+            return []
+
+    def _build_inference_prompt(self, content: str, language: str, file_path: Optional[str] = None) -> str:
+        """Build the prompt for inference"""
+        context = f"File: {file_path}\n" if file_path else ""
+        return f"""{context}Language: {language}
+
+Analyze the following document content and provide:
+1. Category (one word or short phrase describing the document type/topic)
+2. Keywords (comma-separated list of 5-10 important keywords)
+3. Summary (2-3 sentence summary of the content)
+
+Content:
+{content[:1000]}
+
+Respond in this format:
+Category: [category]
+Keywords: [keyword1, keyword2, ...]
+Summary: [summary]"""
+
+    def _parse_inference_response(self, response: str) -> Dict[str, str]:
+        """Parse the structured response from the LLM"""
+        result = {}
+        lines = response.strip().split('\n')
+
+        for line in lines:
+            if line.startswith('Category:'):
+                result['category'] = line.replace('Category:', '').strip()
+            elif line.startswith('Keywords:'):
+                result['keywords'] = line.replace('Keywords:', '').strip()
+            elif line.startswith('Summary:'):
+                result['summary'] = line.replace('Summary:', '').strip()
+
+        return result

--- a/llm_providers/openai_provider.py
+++ b/llm_providers/openai_provider.py
@@ -1,0 +1,206 @@
+"""OpenAI LLM Provider Implementation"""
+
+import logging
+from typing import Dict, List, Optional
+from .base import BaseLLMProvider, LLMResponse, EmbeddingResponse
+
+try:
+    from openai import OpenAI
+except ImportError:
+    OpenAI = None
+
+log = logging.getLogger(__name__)
+
+
+class OpenAIProvider(BaseLLMProvider):
+    """OpenAI API provider implementation"""
+
+    def __init__(self, api_key: str, model: str = "gpt-4o-mini", embedding_model: str = "text-embedding-3-small", **kwargs):
+        """
+        Initialize OpenAI provider
+
+        Args:
+            api_key: OpenAI API key
+            model: Model to use for chat completions (default: gpt-4o-mini)
+            embedding_model: Model to use for embeddings (default: text-embedding-3-small)
+            **kwargs: Additional configuration
+        """
+        super().__init__(api_key, model, **kwargs)
+
+        if OpenAI is None:
+            raise ImportError("openai package is not installed. Install with: pip install openai")
+
+        self.client = OpenAI(api_key=api_key)
+        self.embedding_model = embedding_model
+        self.timeout = kwargs.get('timeout', 30)
+        self.max_retries = kwargs.get('max_retries', 3)
+
+    def infer_category_and_keywords(
+        self,
+        content: str,
+        language: str = 'en',
+        file_path: Optional[str] = None
+    ) -> LLMResponse:
+        """
+        Use OpenAI to infer category, extract keywords, and generate summary
+
+        Args:
+            content: Text content to analyze
+            language: Language of the content
+            file_path: Optional file path for context
+
+        Returns:
+            LLMResponse with category, keywords, and summary
+        """
+        try:
+            prompt = self._build_inference_prompt(content, language, file_path)
+
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are a document analysis assistant. Analyze the provided content and extract structured information."},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=0.3,
+                max_tokens=500,
+                timeout=self.timeout
+            )
+
+            result_text = response.choices[0].message.content
+            parsed = self._parse_inference_response(result_text)
+
+            return LLMResponse(
+                category=parsed.get('category'),
+                keywords=parsed.get('keywords'),
+                summary=parsed.get('summary'),
+                raw_response=result_text,
+                metadata={
+                    'model': self.model,
+                    'provider': 'openai',
+                    'tokens_used': response.usage.total_tokens if hasattr(response, 'usage') else None
+                }
+            )
+
+        except Exception as e:
+            log.error(f"OpenAI inference failed: {e}")
+            raise
+
+    def generate_embedding(self, content: str) -> EmbeddingResponse:
+        """
+        Generate embeddings using OpenAI
+
+        Args:
+            content: Text content to embed
+
+        Returns:
+            EmbeddingResponse with embedding vector
+        """
+        try:
+            # Truncate content if too long
+            max_chars = 8000
+            if len(content) > max_chars:
+                content = content[:max_chars]
+
+            response = self.client.embeddings.create(
+                model=self.embedding_model,
+                input=content,
+                timeout=self.timeout
+            )
+
+            return EmbeddingResponse(
+                embedding=response.data[0].embedding,
+                model=self.embedding_model,
+                metadata={
+                    'provider': 'openai',
+                    'tokens_used': response.usage.total_tokens if hasattr(response, 'usage') else None
+                }
+            )
+
+        except Exception as e:
+            log.error(f"OpenAI embedding failed: {e}")
+            raise
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None
+    ) -> str:
+        """
+        Generic chat completion using OpenAI
+
+        Args:
+            messages: List of message dictionaries
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+
+        Returns:
+            Response text
+        """
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                timeout=self.timeout
+            )
+
+            return response.choices[0].message.content
+
+        except Exception as e:
+            log.error(f"OpenAI chat completion failed: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test OpenAI connection
+
+        Returns:
+            True if connection is successful
+        """
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": "test"}],
+                max_tokens=5,
+                timeout=10
+            )
+            return response.choices[0].message.content is not None
+
+        except Exception as e:
+            log.error(f"OpenAI connection test failed: {e}")
+            return False
+
+    def _build_inference_prompt(self, content: str, language: str, file_path: Optional[str] = None) -> str:
+        """Build the prompt for inference"""
+        context = f"File: {file_path}\n" if file_path else ""
+        return f"""{context}Language: {language}
+
+Analyze the following document content and provide:
+1. Category (one word or short phrase describing the document type/topic)
+2. Keywords (comma-separated list of 5-10 important keywords)
+3. Summary (2-3 sentence summary of the content)
+
+Content:
+{content[:1000]}
+
+Respond in this format:
+Category: [category]
+Keywords: [keyword1, keyword2, ...]
+Summary: [summary]"""
+
+    def _parse_inference_response(self, response: str) -> Dict[str, str]:
+        """Parse the structured response from the LLM"""
+        result = {}
+        lines = response.strip().split('\n')
+
+        for line in lines:
+            if line.startswith('Category:'):
+                result['category'] = line.replace('Category:', '').strip()
+            elif line.startswith('Keywords:'):
+                result['keywords'] = line.replace('Keywords:', '').strip()
+            elif line.startswith('Summary:'):
+                result['summary'] = line.replace('Summary:', '').strip()
+
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,3 +144,5 @@ wrapt==1.16.0
 xkit==0.0.0
 zeroconf==0.24.4
 zipp==3.19.2
+openai>=1.0.0
+anthropic>=0.18.0


### PR DESCRIPTION
Implement a flexible LLM backend abstraction that allows switching between OpenAI, Anthropic Claude, and Ollama based on token-key configuration settings.

Key Features:
- Unified interface for all LLM providers (BaseLLMProvider)
- Support for OpenAI (GPT-4o-mini, embeddings)
- Support for Anthropic Claude (Claude 3.5 Haiku)
- Support for Ollama (local models, privacy-first)
- Token-key based automatic provider selection
- Graceful fallback between providers
- Configuration via environment variables

New Components:
- llm_providers/base.py: Abstract base class with standard interface
- llm_providers/openai_provider.py: OpenAI implementation
- llm_providers/anthropic_provider.py: Anthropic Claude implementation
- llm_providers/ollama_provider.py: Ollama local model implementation
- llm_providers/factory.py: Provider factory with auto-selection logic
- indexer/index_worker.py: Modernized queue worker using LLM abstraction
- .env.example: Configuration template
- llm_providers/README.md: Comprehensive documentation

The abstraction addresses upgrade recommendations from upgrade-recommendation.md:
- Replaces legacy inference_server.py with modern LLM APIs
- Adds provider abstraction for OpenAI, Ollama, and other backends
- Implements timeouts and retry logic
- Supports embeddings for semantic search
- Centralizes secret management via environment variables
- Enables hybrid cloud/local deployment strategies

Usage:
  LLM_PROVIDER=openai python indexer/index_worker.py LLM_PROVIDER=anthropic python indexer/index_worker.py LLM_PROVIDER=ollama python indexer/index_worker.py

Closes issues related to indexing modernization and LLM integration.