### PR TITLE
Add file preview pages with router system

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -354,6 +354,10 @@ def preview(filename):
         return render_template('pdf_preview.html', file_url=f"/preview/{filename}")
     elif filename.endswith('.docx') or filename.lower().endswith('.doc'):
         return render_template('doc_preview.html', file_url=f"/preview/{filename}")
+    elif filename.endswith('.xlsx') or filename.lower().endswith('.xls'):
+        return render_template('excel_preview.html', file_url=f"/preview/{filename}")
+    elif filename.lower().endswith('.csv'):
+        return render_template('csv_preview.html', file_url=f"/preview/{filename}")
     else:
         return "File type not supported", 400
 

--- a/static/csv_preview.html
+++ b/static/csv_preview.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSV Preview</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 20px;
+      background-color: #f0f0f0;
+      font-family: Arial, sans-serif;
+    }
+    #csv-container {
+      width: 100%;
+      background-color: white;
+      padding: 20px;
+      overflow: auto;
+      box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    }
+    #csv-info {
+      margin-bottom: 15px;
+      padding: 10px;
+      background-color: #e8f4f8;
+      border-radius: 5px;
+      font-size: 14px;
+    }
+    #csv-content {
+      overflow-x: auto;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      font-size: 12px;
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 8px;
+      text-align: left;
+    }
+    th {
+      background-color: #2196F3;
+      color: white;
+      font-weight: bold;
+      position: sticky;
+      top: 0;
+    }
+    tr:nth-child(even) {
+      background-color: #f9f9f9;
+    }
+    tr:hover {
+      background-color: #f5f5f5;
+    }
+    .error-message {
+      color: red;
+      padding: 20px;
+      background-color: #ffe6e6;
+      border: 1px solid #ff0000;
+      border-radius: 5px;
+      margin: 20px 0;
+    }
+    .loading {
+      text-align: center;
+      padding: 20px;
+      font-size: 16px;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <div id="csv-container">
+    <div class="loading">Loading CSV file...</div>
+    <div id="csv-info" style="display: none;"></div>
+    <div id="csv-content"></div>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script>
+    const fileUrl = "{{ file_url }}";
+
+    fetch(fileUrl)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.text();
+      })
+      .then(csvText => {
+        // Hide loading message
+        document.querySelector('.loading').style.display = 'none';
+
+        // Parse CSV using XLSX
+        const workbook = XLSX.read(csvText, { type: 'string' });
+        const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+
+        // Get data as array of arrays
+        const data = XLSX.utils.sheet_to_json(worksheet, { header: 1 });
+
+        // Display info
+        const infoDiv = document.getElementById('csv-info');
+        infoDiv.style.display = 'block';
+        infoDiv.innerHTML = `<strong>Rows:</strong> ${data.length} | <strong>Columns:</strong> ${data[0] ? data[0].length : 0}`;
+
+        // Create table
+        let tableHtml = '<table id="csv-table">';
+
+        // Add header row if exists
+        if (data.length > 0) {
+          tableHtml += '<thead><tr>';
+          data[0].forEach(cell => {
+            tableHtml += `<th>${escapeHtml(cell !== undefined ? String(cell) : '')}</th>`;
+          });
+          tableHtml += '</tr></thead>';
+        }
+
+        // Add data rows
+        tableHtml += '<tbody>';
+        for (let i = 1; i < data.length; i++) {
+          tableHtml += '<tr>';
+          const row = data[i];
+          const maxCols = data[0].length;
+          for (let j = 0; j < maxCols; j++) {
+            const cell = row[j];
+            tableHtml += `<td>${escapeHtml(cell !== undefined ? String(cell) : '')}</td>`;
+          }
+          tableHtml += '</tr>';
+        }
+        tableHtml += '</tbody></table>';
+
+        document.getElementById('csv-content').innerHTML = tableHtml;
+      })
+      .catch(err => {
+        console.error(err);
+        document.querySelector('.loading').style.display = 'none';
+        document.getElementById('csv-content').innerHTML =
+          `<div class="error-message">Error loading CSV file: ${err.message}</div>`;
+      });
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+  </script>
+</body>
+</html>

--- a/static/excel_preview.html
+++ b/static/excel_preview.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Excel Preview</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 20px;
+      background-color: #f0f0f0;
+      font-family: Arial, sans-serif;
+    }
+    #excel-container {
+      width: 100%;
+      background-color: white;
+      padding: 20px;
+      overflow: auto;
+      box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    }
+    #sheet-selector {
+      margin-bottom: 15px;
+      padding: 10px;
+      background-color: #e8e8e8;
+      border-radius: 5px;
+    }
+    #sheet-selector label {
+      margin-right: 10px;
+      font-weight: bold;
+    }
+    #sheet-selector select {
+      padding: 5px 10px;
+      border: 1px solid #ccc;
+      border-radius: 3px;
+      font-size: 14px;
+    }
+    #excel-content {
+      overflow-x: auto;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      font-size: 12px;
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 8px;
+      text-align: left;
+    }
+    th {
+      background-color: #4CAF50;
+      color: white;
+      font-weight: bold;
+    }
+    tr:nth-child(even) {
+      background-color: #f9f9f9;
+    }
+    tr:hover {
+      background-color: #f5f5f5;
+    }
+    .error-message {
+      color: red;
+      padding: 20px;
+      background-color: #ffe6e6;
+      border: 1px solid #ff0000;
+      border-radius: 5px;
+      margin: 20px 0;
+    }
+    .loading {
+      text-align: center;
+      padding: 20px;
+      font-size: 16px;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <div id="excel-container">
+    <div class="loading">Loading Excel file...</div>
+    <div id="sheet-selector" style="display: none;">
+      <label for="sheet-select">Select Sheet:</label>
+      <select id="sheet-select"></select>
+    </div>
+    <div id="excel-content"></div>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script>
+    const fileUrl = "{{ file_url }}";
+    let workbook = null;
+
+    fetch(fileUrl)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.arrayBuffer();
+      })
+      .then(arrayBuffer => {
+        // Read the workbook
+        workbook = XLSX.read(arrayBuffer, { type: 'array' });
+
+        // Hide loading message
+        document.querySelector('.loading').style.display = 'none';
+
+        // Show sheet selector if there are multiple sheets
+        const sheetSelector = document.getElementById('sheet-selector');
+        const sheetSelect = document.getElementById('sheet-select');
+
+        if (workbook.SheetNames.length > 1) {
+          sheetSelector.style.display = 'block';
+
+          // Populate sheet selector
+          workbook.SheetNames.forEach((sheetName, index) => {
+            const option = document.createElement('option');
+            option.value = index;
+            option.textContent = sheetName;
+            sheetSelect.appendChild(option);
+          });
+
+          // Add change listener
+          sheetSelect.addEventListener('change', (e) => {
+            displaySheet(workbook.SheetNames[e.target.value]);
+          });
+        }
+
+        // Display first sheet
+        displaySheet(workbook.SheetNames[0]);
+      })
+      .catch(err => {
+        console.error(err);
+        document.querySelector('.loading').style.display = 'none';
+        document.getElementById('excel-content').innerHTML =
+          `<div class="error-message">Error loading Excel file: ${err.message}</div>`;
+      });
+
+    function displaySheet(sheetName) {
+      const worksheet = workbook.Sheets[sheetName];
+
+      // Convert sheet to HTML table
+      const htmlTable = XLSX.utils.sheet_to_html(worksheet, {
+        id: 'excel-table',
+        editable: false
+      });
+
+      document.getElementById('excel-content').innerHTML = htmlTable;
+    }
+  </script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -335,7 +335,7 @@
       document.getElementById('preview-button').addEventListener('click', () => {
         filePath = `${currentFilePath}`
         const ext = filePath.split('.').pop().toLowerCase();
-        if (["docx", "doc", "pdf"].contains(ext)){
+        if (["docx", "doc", "pdf", "xls", "xlsx", "csv"].contains(ext)){
           const previewPane = document.getElementById('preview-pane');
           const previewUrl = `/doc_preview/${encodeURIComponent(`${currentFilePath}`)}`;
           console.log('Preview Url:', previewUrl);


### PR DESCRIPTION
Implemented a preview system for xls, xlsx, and csv file formats following the existing pattern used for docx and pdf files:
- Created excel_preview.html using SheetJS library to render Excel files with multi-sheet support
- Created csv_preview.html using SheetJS library to render CSV files as tables
- Updated server routing to handle xls, xlsx, and csv file types
- Extended preview button in index.html to trigger previews for these formats