### PR TITLE
Port server to Postgres and add semantic search / topic graph / ask

### DIFF
--- a/common/retrieval.py
+++ b/common/retrieval.py
@@ -1,0 +1,257 @@
+"""Retrieval service - the canonical RAG/topic-graph API.
+
+Transport-agnostic. HTTP routes, MCP tools, the inference_server's chat
+path - any consumer instantiates RetrievalService(session, embedders)
+and calls these methods. All return plain dataclasses, never Flask
+objects, so adapters can serialize however they like.
+
+To add a new transport:
+  1. Build the request payload into the typed args below.
+  2. Open a SQLAlchemy session via common.db.make_session_factory().
+  3. Construct RetrievalService(session, embedders, llm=optional).
+  4. Call search_chunks / topic_neighbors / ask.
+  5. Serialize the dataclass result into your transport's wire format.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Iterable, List, Optional
+
+from sqlalchemy import select
+
+from common.db import Chunk, Document, Topic, TopicEdge
+from llm_providers.base import BaseLLMProvider
+from llm_providers.embeddings import EmbedderRegistry, EmbeddingRole
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class SearchFilters:
+    file_type: Optional[str] = None
+    inferred_category: Optional[str] = None
+    category: Optional[str] = None
+    topic_ids: Optional[List[int]] = None
+
+
+@dataclass
+class ChunkHit:
+    chunk_id: int
+    document_id: int
+    topic_id: Optional[int]
+    topic_name: Optional[str]
+    chunk_idx: int
+    aspect: Optional[str]
+    text: str
+    path: str
+    summary: Optional[str]
+    inferred_category: Optional[str]
+    score: float  # cosine similarity in [-1, 1]; closer to 1 == more similar
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class TopicNeighbor:
+    topic_id: int
+    name: str
+    description: Optional[str]
+    kind: str
+    weight: float
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class Citation:
+    chunk_id: int
+    document_id: int
+    topic_id: Optional[int]
+    topic_name: Optional[str]
+    path: str
+    score: float
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class AskResult:
+    answer: str
+    citations: List[Citation] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {"answer": self.answer, "citations": [c.to_dict() for c in self.citations]}
+
+
+class RetrievalService:
+    def __init__(
+        self,
+        session,
+        embedders: EmbedderRegistry,
+        llm: Optional[BaseLLMProvider] = None,
+    ):
+        self.session = session
+        self.embedders = embedders
+        self.llm = llm
+
+    # ---- semantic search -----------------------------------------------------
+
+    def search_chunks(
+        self,
+        query: str,
+        top_k: int = 10,
+        filters: Optional[SearchFilters] = None,
+    ) -> List[ChunkHit]:
+        if not query or not query.strip():
+            return []
+
+        embedder = self.embedders.get(EmbeddingRole.QUERY)
+        qvec = embedder.encode(query).embedding
+
+        distance = Chunk.embedding.cosine_distance(qvec)
+        stmt = (
+            select(
+                Chunk.id,
+                Chunk.document_id,
+                Chunk.topic_id,
+                Chunk.chunk_idx,
+                Chunk.aspect,
+                Chunk.text,
+                distance.label("distance"),
+                Document.path,
+                Document.summary,
+                Document.inferred_category,
+                Topic.name.label("topic_name"),
+            )
+            .join(Document, Chunk.document_id == Document.id)
+            .outerjoin(Topic, Chunk.topic_id == Topic.id)
+        )
+        if filters:
+            if filters.file_type:
+                stmt = stmt.where(Document.file_type == filters.file_type)
+            if filters.inferred_category:
+                stmt = stmt.where(Document.inferred_category == filters.inferred_category)
+            if filters.category:
+                stmt = stmt.where(Document.category == filters.category)
+            if filters.topic_ids:
+                stmt = stmt.where(Chunk.topic_id.in_(filters.topic_ids))
+        stmt = stmt.order_by(distance).limit(top_k)
+
+        return [
+            ChunkHit(
+                chunk_id=r.id,
+                document_id=r.document_id,
+                topic_id=r.topic_id,
+                topic_name=r.topic_name,
+                chunk_idx=r.chunk_idx,
+                aspect=r.aspect,
+                text=r.text,
+                path=r.path,
+                summary=r.summary,
+                inferred_category=r.inferred_category,
+                score=1.0 - float(r.distance),
+            )
+            for r in self.session.execute(stmt).all()
+        ]
+
+    # ---- topic graph ---------------------------------------------------------
+
+    def topic_neighbors(
+        self,
+        topic_id: int,
+        kinds: Optional[Iterable[str]] = None,
+        limit: int = 20,
+    ) -> List[TopicNeighbor]:
+        stmt = (
+            select(
+                TopicEdge.dst_topic_id,
+                TopicEdge.kind,
+                TopicEdge.weight,
+                Topic.name.label("dst_name"),
+                Topic.description.label("dst_description"),
+            )
+            .join(Topic, Topic.id == TopicEdge.dst_topic_id)
+            .where(TopicEdge.src_topic_id == topic_id)
+        )
+        if kinds:
+            stmt = stmt.where(TopicEdge.kind.in_(list(kinds)))
+        stmt = stmt.order_by(TopicEdge.weight.desc()).limit(limit)
+
+        return [
+            TopicNeighbor(
+                topic_id=r.dst_topic_id,
+                name=r.dst_name,
+                description=r.dst_description,
+                kind=r.kind,
+                weight=float(r.weight),
+            )
+            for r in self.session.execute(stmt).all()
+        ]
+
+    # ---- end-to-end RAG ------------------------------------------------------
+
+    def ask(
+        self,
+        query: str,
+        top_k: int = 5,
+        filters: Optional[SearchFilters] = None,
+    ) -> AskResult:
+        if self.llm is None:
+            raise ValueError(
+                "RetrievalService.ask() requires an llm provider. "
+                "Pass one to RetrievalService(..., llm=...)."
+            )
+
+        hits = self.search_chunks(query, top_k=top_k, filters=filters)
+        if not hits:
+            return AskResult(answer="No matching documents found.", citations=[])
+
+        # Group by topic so the prompt is organised, not a flat dump.
+        grouped: dict = {}
+        for h in hits:
+            key = (h.topic_id, h.topic_name or "Uncategorized")
+            grouped.setdefault(key, []).append(h)
+
+        sections = []
+        for (topic_id, topic_name), chunks in grouped.items():
+            section = [f"## Topic: {topic_name}"]
+            for c in chunks:
+                section.append(
+                    f"[chunk {c.chunk_id} | {c.path} | score={c.score:.2f}]\n{c.text}"
+                )
+            sections.append("\n".join(section))
+        context = "\n\n".join(sections)
+
+        system = (
+            "You answer questions strictly from the provided document excerpts. "
+            "Cite supporting chunks inline as [chunk N]. If the context does not "
+            "contain the answer, say so."
+        )
+        user = f"Question: {query}\n\nContext:\n{context}\n\nAnswer:"
+        answer = self.llm.chat_completion(
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            temperature=0.2,
+        )
+
+        return AskResult(
+            answer=answer,
+            citations=[
+                Citation(
+                    chunk_id=h.chunk_id,
+                    document_id=h.document_id,
+                    topic_id=h.topic_id,
+                    topic_name=h.topic_name,
+                    path=h.path,
+                    score=h.score,
+                )
+                for h in hits
+            ],
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,11 +83,13 @@ services:
     container_name: server
     environment:
       <<: *pg-env
+      BASE_DIR: ${BASE_DIR:-/data}
     ports:
       - "5000:5000"
     volumes:
       - ./shared_data:/data
       - ./common:/app/common
+      - ./llm_providers:/app/llm_providers
       - ./static:/app/static
       - ./templates:/app/templates
       - ./MyLogger.py:/app/MyLogger.py

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,12 +3,13 @@ FROM python:3.10-slim
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y libmagic1 && \
-    pip install --no-cache-dir -r requirements.txt
+    apt-get install -y --no-install-recommends libmagic1 build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY server.py .
-COPY ../MyLogger.py .
-COPY ../static ./static
-COPY ../templates ./templates
+COPY routes_retrieval.py .
 
 CMD ["python", "server.py"]

--- a/server/routes_retrieval.py
+++ b/server/routes_retrieval.py
@@ -1,0 +1,83 @@
+"""HTTP transport adapter for the RetrievalService.
+
+This is one of multiple planned consumer adapters: HTTP (here), MCP
+(separate module), inference_server chat hook (separate module). All
+three call into common.retrieval.RetrievalService; the only thing that
+differs is request/response framing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from flask import Blueprint, jsonify, request
+
+from common.retrieval import RetrievalService, SearchFilters
+
+log = logging.getLogger(__name__)
+
+
+def make_retrieval_blueprint(session_factory, embedders, llm_factory):
+    """Build the blueprint.
+
+    session_factory: callable returning a SQLAlchemy session.
+    embedders:       EmbedderRegistry (built once, shared).
+    llm_factory:     callable returning a BaseLLMProvider, used by /ask.
+                     Pulled lazily so /search/semantic doesn't require an
+                     LLM provider to be configured.
+    """
+    bp = Blueprint("retrieval", __name__)
+
+    def _filters_from_payload(payload: dict) -> Optional[SearchFilters]:
+        raw = payload.get("filters") or {}
+        if not raw:
+            return None
+        return SearchFilters(
+            file_type=raw.get("file_type"),
+            inferred_category=raw.get("inferred_category"),
+            category=raw.get("category"),
+            topic_ids=raw.get("topic_ids"),
+        )
+
+    @bp.route("/search/semantic", methods=["POST"])
+    def search_semantic():
+        payload = request.get_json(silent=True) or {}
+        query = (payload.get("query") or "").strip()
+        if not query:
+            return jsonify({"error": "query is required"}), 400
+        top_k = int(payload.get("top_k", 10))
+        filters = _filters_from_payload(payload)
+        with session_factory() as session:
+            service = RetrievalService(session, embedders)
+            hits = service.search_chunks(query, top_k=top_k, filters=filters)
+        return jsonify({"hits": [h.to_dict() for h in hits]})
+
+    @bp.route("/topics/<int:topic_id>/neighbors", methods=["GET"])
+    def topic_neighbors(topic_id: int):
+        kinds_arg = request.args.getlist("kind") or None
+        limit = int(request.args.get("limit", 20))
+        with session_factory() as session:
+            service = RetrievalService(session, embedders)
+            neighbors = service.topic_neighbors(topic_id, kinds=kinds_arg, limit=limit)
+        return jsonify({"topic_id": topic_id, "neighbors": [n.to_dict() for n in neighbors]})
+
+    @bp.route("/ask", methods=["POST"])
+    def ask():
+        payload = request.get_json(silent=True) or {}
+        query = (payload.get("query") or "").strip()
+        if not query:
+            return jsonify({"error": "query is required"}), 400
+        top_k = int(payload.get("top_k", 5))
+        filters = _filters_from_payload(payload)
+        try:
+            llm = llm_factory()
+        except Exception as exc:
+            log.error("LLM provider unavailable: %s", exc)
+            return jsonify({"error": "no LLM provider configured"}), 503
+        with session_factory() as session:
+            service = RetrievalService(session, embedders, llm=llm)
+            result = service.ask(query, top_k=top_k, filters=filters)
+        return jsonify(result.to_dict())
+
+    return bp

--- a/server/server.py
+++ b/server/server.py
@@ -1,413 +1,245 @@
-import os
-import threading
-from flask import Flask, jsonify, request, render_template, Response, send_from_directory, g, abort
-from flask_cors import CORS
-from sqlalchemy import create_engine, Column, Integer, String, Float
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.orm.exc import NoResultFound
-import time
-import requests
-import pefile
-import magic
-from tika import parser
-from langdetect import detect
+"""HTTP server: file browser + topic-graph retrieval API.
+
+DB writes are owned by the indexer/scanner; this server is read-mostly.
+Retrieval endpoints (/search/semantic, /topics/<id>/neighbors, /ask)
+live in routes_retrieval and call the transport-agnostic
+RetrievalService in common.retrieval, so the same logic is reusable
+from MCP / inference_server hooks later.
+"""
+
 import logging
-import sys
 import os
-# Add parent directory to path for imports
+import sys
+
+from flask import (
+    Flask,
+    abort,
+    g,
+    jsonify,
+    render_template,
+    request,
+    send_from_directory,
+)
+from flask_cors import CORS
+from sqlalchemy import func, select
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from MyLogger import Logger
-from document_preprocessor import preprocess_for_llm
+from common.db import Document, make_engine, make_session_factory
+from common.retrieval import RetrievalService  # noqa: F401  (kept for direct import use)
+from llm_providers import get_llm_provider
+from llm_providers.embeddings import build_registry
+from llm_providers.factory import ProviderConfig
+from server.routes_retrieval import make_retrieval_blueprint
 
-# Create a logger instance
-log = Logger(log_name='mserver', log_level=logging.DEBUG).get_logger()
 
-# Database setup
-DATABASE_URI = 'sqlite:///instance/files.db'
-Base = declarative_base()
-engine = create_engine(DATABASE_URI)
-SessionLocal = scoped_session(sessionmaker(bind=engine))
+log = Logger(log_name="mserver", log_level=logging.DEBUG).get_logger()
 
-# Define the FileMetadata model
-class FileMetadata(Base):
-    __tablename__ = 'file_metadata'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    path = Column(String, unique=True, nullable=False)
-    size = Column(Integer, nullable=False)
-    modification_date = Column(Float, nullable=False)
-    category = Column(String, nullable=True)
-    inferred_category = Column(String, nullable=True)
-    keywords = Column(String, nullable=True)
-    summary = Column(String, nullable=True)
-    content = Column(String, nullable=False)
-    file_type = Column(String, nullable=True)
-    creator_software = Column(String, nullable=True)
-    origin_date = Column(String, nullable=True)
-    pe_info = Column(String, nullable=True)  # New field for PE info
 
-# Ensure database tables are created
-Base.metadata.create_all(engine)
+BASE_DIR = os.environ.get("BASE_DIR", "/data")
+STATIC_DIR = os.environ.get("STATIC_DIR", "/app/static")
+THUMBNAILS_DIR = os.environ.get(
+    "THUMBNAILS_DIR", "/var/server/data/meta-server/thumbnails"
+)
 
-# Define the DirectoryMetadata model
-class DirectoryMetadata(Base):
-    __tablename__ = 'directory_metadata'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    path = Column(String, unique=True, nullable=False)
-    file_count = Column(Integer, nullable=False)
-    total_size = Column(Integer, nullable=False)
-    modification_date = Column(Float, nullable=False)
 
-# Ensure database tables are created
-Base.metadata.create_all(engine)
+# ---------- shared singletons --------------------------------------------------
 
-# Initialize Flask app
-app = Flask(__name__, static_folder='static', static_url_path='')
+engine = make_engine()
+SessionFactory = make_session_factory(engine)
+embedders = build_registry()
+
+
+def _llm_factory():
+    return get_llm_provider(provider_name=os.getenv("LLM_PROVIDER"), config=ProviderConfig())
+
+
+# ---------- Flask app ----------------------------------------------------------
+
+app = Flask(__name__, static_folder="static", static_url_path="")
 CORS(app)
+app.register_blueprint(make_retrieval_blueprint(SessionFactory, embedders, _llm_factory))
 
-@app.teardown_appcontext
-def remove_session(exception=None):
-    SessionLocal.remove()
-
-# Initialize a queue for files to be scanned
-scan_queue = []
-
-# Lock for thread safety
-queue_lock = threading.Lock()
-
-# Function to process the scan queue
-def process_scan_queue():
-    while True:
-        with queue_lock:
-            if scan_queue:
-                file_path = scan_queue.pop(0)
-                log.info(f"Queue processing: {file_path}")
-                scan_and_update_file(file_path)
-        time.sleep(1)  # Adjust the sleep time as needed
-
-# Start a background thread to process the queue
-scan_thread = threading.Thread(target=process_scan_queue)
-scan_thread.daemon = True
-scan_thread.start()
-
-# Function to extract text using Tika server
-def extract_text_with_tika(file_path):
-    with open(file_path, 'rb') as file:
-        response = requests.put('http://localhost:9998/tika', files={'file': file})
-        if response.status_code == 200:
-            return response.text
-        else:
-            return ""
-
-# Function to extract metadata from the file path
-def infer_metadata_from_path(file_path):
-    parts = file_path.split(os.sep)
-    category = parts[-2] if len(parts) > 1 else 'Unknown'
-    return category
-
-# Function to use python-magic for file type detection
-def detect_file_type(file_path):
-    file_magic = magic.Magic(mime=True)
-    mime_type = file_magic.from_file(file_path)
-    file_type = mime_type.split('/')[0]
-    creator_software = mime_type.split('/')[1] if len(mime_type.split('/')) > 1 else 'Unknown'
-    return mime_type, file_type, creator_software
-
-# Function to get PE file info
-def get_pe_info(file_path):
-    try:
-        pe = pefile.PE(file_path)
-        pe_info = {
-            "entry_point": pe.OPTIONAL_HEADER.AddressOfEntryPoint,
-            "image_base": pe.OPTIONAL_HEADER.ImageBase,
-            "number_of_sections": pe.FILE_HEADER.NumberOfSections
-        }
-        return str(pe_info)
-    except Exception as e:
-        return str(e)
-
-# Function to scan and update a single file
-def scan_and_update_file(file_path):
-    session = SessionLocal()
-    content = ""
-    inferred_category = None
-    keywords = None
-    summary = None
-    origin_date = str(os.path.getmtime(file_path))
-
-    mime_type, file_type, creator_software = detect_file_type(file_path)
-    size = os.path.getsize(file_path)
-    modification_date = os.path.getmtime(file_path)
-    category = infer_metadata_from_path(file_path)
-    pe_info = ""
-
-    if file_type == 'image':
-        inferred_category = 'Image'
-    elif file_path.lower().endswith('.exe'):
-        content = get_pe_info(file_path)
-        inferred_category = 'Executable'
-        pe_info = content
-    elif file_path.lower().endswith('.pdf') or file_path.lower().endswith('.docx'):
-        parsed = parser.from_file(file_path)
-        raw_content = parsed.get('content', '') if parsed else ''
-
-        if raw_content:
-            # Detect language from raw content
-            source_lang = detect(raw_content[:500]) if raw_content else 'unknown'
-
-            # Use enhanced preprocessing for better LLM analysis
-            cleaned_content = preprocess_for_llm(
-                raw_content,
-                max_chars=4000,
-                aggressive_cleaning=True
-            )
-
-            payload = {
-                'file_path': file_path,
-                'content': cleaned_content,  # Send cleaned content instead of raw
-                'language': source_lang
-            }
-
-            response = requests.post('http://localhost:5001/infer', json=payload)
-            if response.status_code == 200:
-                data = response.json()
-                inferred_category = data.get('category')
-                keywords = data.get('keywords')
-                summary = data.get('summary')
-
-                if file_path.lower().endswith('.pdf') or file_path.lower().endswith('.docx'):
-                    content = summary
-            else:
-                log.info(f"Error processing file {file_path}: {response.text}")
-                content = cleaned_content[:5000]  # Fallback to cleaned content
-        else:
-            content = ""
-    else:
-        # Other file types - extract and preprocess with Tika
-        raw_content = extract_text_with_tika(file_path)
-        if raw_content:
-            # Apply basic preprocessing for other file types
-            content = preprocess_for_llm(raw_content, max_chars=5000, aggressive_cleaning=False)
-        else:
-            content = ""
-
-    metadata = FileMetadata(
-        path=file_path,
-        size=size,
-        modification_date=modification_date,
-        category=category,
-        inferred_category=inferred_category,
-        keywords=keywords,
-        summary=summary,
-        content=content,
-        file_type=file_type,
-        creator_software=creator_software,
-        origin_date=origin_date,
-        pe_info=pe_info
-    )
-    session.add(metadata)
-    session.commit()
-    session.close()
 
 @app.before_request
 def before_request():
-    # Example of setting variables to be accessed later
     g.endpoint = request.endpoint
     g.full_path = request.full_path
 
+
 @app.errorhandler(404)
-def page_not_found(e):
-    # Access the stored endpoint
-    endpoint = getattr(g, 'endpoint', 'Unknown')
-    full_path = getattr(g, 'full_path', 'Unknown')
-    log_message = (
-        f"404 error at {request.url} - IP: {request.remote_addr} - "
-        f"\nEndpoint: {endpoint}"
-        f"\nfull_path: {full_path}"
+def page_not_found(_):
+    log.info(
+        "404 at %s ip=%s endpoint=%s full_path=%s",
+        request.url,
+        request.remote_addr,
+        getattr(g, "endpoint", "?"),
+        getattr(g, "full_path", "?"),
     )
-    app.logger.info(log_message)
     return "<h2>Page not found</h2>", 404
 
-@app.route('/files', methods=['GET'])
-def list_files():
-    session = SessionLocal()
-    relative_directory = request.args.get('directory', '/')
-    directory = os.path.join(BASE_DIR, relative_directory.lstrip('/'))
-    files = []
-    file_list = os.scandir(directory)
-    for entry in file_list:
-        if entry.name.startswith('.'):
-            continue
-        file_path = os.path.join(directory, entry.name)
-        relative_path = os.path.relpath(file_path, BASE_DIR)
 
-        # Check if metadata exists in the database
-        metadata = None
-        try:
+# ---------- file browser -------------------------------------------------------
+
+def _doc_to_metadata(doc: Document) -> dict:
+    return {
+        "id": doc.id,
+        "path": doc.path,
+        "size": doc.size,
+        "modification_date": doc.modification_date,
+        "category": doc.category,
+        "inferred_category": doc.inferred_category,
+        "keywords": doc.keywords,
+        "summary": doc.summary,
+        "file_type": doc.file_type,
+        "creator_software": doc.creator_software,
+        "origin_date": doc.origin_date,
+        "pe_info": doc.pe_info,
+    }
+
+
+@app.route("/files", methods=["GET"])
+def list_files():
+    relative_directory = request.args.get("directory", "/")
+    directory = os.path.join(BASE_DIR, relative_directory.lstrip("/"))
+    if not os.path.isdir(directory):
+        return jsonify([])
+
+    results = []
+    with SessionFactory() as session:
+        for entry in os.scandir(directory):
+            if entry.name.startswith("."):
+                continue
+            file_path = os.path.join(directory, entry.name)
+            relative_path = os.path.relpath(file_path, BASE_DIR)
+
             if entry.is_dir():
-                metadata = session.query(DirectoryMetadata).filter_by(path=file_path).one()
+                # Aggregate from documents whose path starts with this directory.
+                prefix = file_path.rstrip("/") + "/"
+                file_count = session.execute(
+                    select(func.count(Document.id)).where(Document.path.like(prefix + "%"))
+                ).scalar_one()
+                total_size = session.execute(
+                    select(func.coalesce(func.sum(Document.size), 0)).where(
+                        Document.path.like(prefix + "%")
+                    )
+                ).scalar_one()
+                results.append({
+                    "path": relative_path,
+                    "is_directory": True,
+                    "id": None,
+                    "metadata": {
+                        "path": relative_path,
+                        "size": int(total_size or 0),
+                        "modification_date": entry.stat().st_mtime,
+                        "file_count": int(file_count or 0),
+                    },
+                })
             else:
-                metadata = session.query(FileMetadata).filter_by(path=file_path).one()
-        except NoResultFound:
-            pass
-        files.append({
-            'path': relative_path,
-            'is_directory': entry.is_dir(),
-            'id': entry.name if entry.is_file() else None,
-            'metadata': {
-                'id': getattr(metadata, 'id', None),
-                'path': getattr(metadata, 'path', relative_path),
-                'size': getattr(metadata, 'size', 0) if not entry.is_dir() else getattr(metadata, 'total_size', 0),
-                'modification_date': getattr(metadata, 'modification_date', None),
-                'category': getattr(metadata, 'category', None),
-                'inferred_category': getattr(metadata, 'inferred_category', None),
-                'keywords': getattr(metadata, 'keywords', None),
-                'summary': getattr(metadata, 'summary', None),
-                'file_type': getattr(metadata, 'file_type', None),
-                'creator_software': getattr(metadata, 'creator_software', None),
-                'origin_date': getattr(metadata, 'origin_date', None),
-                'pe_info': getattr(metadata, 'pe_info', None) if not entry.is_dir() else None,
-                'file_count': getattr(metadata, 'file_count', None) if entry.is_dir() else None
-            }
+                doc = session.execute(
+                    select(Document).where(Document.path == file_path)
+                ).scalar_one_or_none()
+                meta = _doc_to_metadata(doc) if doc else {
+                    "path": relative_path,
+                    "size": entry.stat().st_size,
+                    "modification_date": entry.stat().st_mtime,
+                }
+                results.append({
+                    "path": relative_path,
+                    "is_directory": False,
+                    "id": entry.name,
+                    "metadata": meta,
+                })
+
+    results.sort(key=lambda x: (not x["is_directory"], x["path"].lower()))
+    return jsonify(results)
+
+
+@app.route("/files/<path:file_id>", methods=["GET"])
+def get_file(file_id):
+    file_path = os.path.join(BASE_DIR, file_id.lstrip("/"))
+    with SessionFactory() as session:
+        doc = session.execute(
+            select(Document).where(Document.path == file_path)
+        ).scalar_one_or_none()
+        if doc is None:
+            log.info("/files/ not found: %s", file_path)
+            return jsonify({"error": "File not found"}), 404
+        return jsonify({
+            "metadata": _doc_to_metadata(doc),
+            "content": doc.summary,  # full text now lives in chunks
         })
 
-    # Sort folders first, then files, both alphabetically
-    files.sort(key=lambda x: (not x['is_directory'], x['path'].lower()))
-    response = jsonify(files)
-    session.close()
-    return response
 
-# Endpoint to get file details and content
-@app.route('/files/<path:file_id>', methods=['GET'])
-def get_file(file_id):
-    session = SessionLocal()
-    file_path = os.path.join(BASE_DIR, file_id.lstrip('/'))
-    file = session.query(FileMetadata).filter_by(path=file_path).first()
+# ---------- static / preview / template routes (unchanged) --------------------
 
-    if file:
-        metadata = {
-            'id': file.id,
-            'path': file.path,
-            'size': file.size,
-            'modification_date': file.modification_date,
-            'category': file.category,
-            'inferred_category': file.inferred_category,
-            'keywords': file.keywords,
-            'summary': file.summary,
-            'file_type': file.file_type,
-            'creator_software': file.creator_software,
-            'origin_date': file.origin_date,
-            'pe_info': file.pe_info,
-            'file_count': 0  # Not applicable for files
-        }
-        response = jsonify({'metadata': metadata, 'content': file.content})
-        session.close()
-        return response
-    else:
-        with queue_lock:
-            scan_queue.append(file_path)
-        log.info(f"/files/ not found: {file_path}")
-        session.close()
-        return jsonify({'error': 'File not found'}), 404
-
-# Route to serve the HTML file
-@app.route('/')
+@app.route("/")
 def serve_html():
-    return send_from_directory(app.static_folder, 'index.html')
+    return send_from_directory(app.static_folder, "index.html")
 
-# Route for translation (not implemented )
-@app.route('/translate', methods=['POST'])
+
+@app.route("/translate", methods=["POST"])
 def translate():
-    data = request.json
-    text = data.get('text')
-    target_lang = data.get('target_lang', 'ja')
-    translated_text = f"Translated to {target_lang}: {text}"
-    return jsonify({'translated_text': translated_text})
+    data = request.json or {}
+    text = data.get("text")
+    target_lang = data.get("target_lang", "ja")
+    return jsonify({"translated_text": f"Translated to {target_lang}: {text}"})
 
-@app.route('/thumbnails/<path:filename>')
+
+@app.route("/thumbnails/<path:filename>")
 def serve_thumbnail(filename):
-    # Remove specific prefix from the filename if necessary
-    prefix = 'win95/mcrlnsalg/'
+    prefix = "win95/mcrlnsalg/"
     if filename.startswith(prefix):
         filename = filename[len(prefix):]
 
-    log.debug(f"Processed filename after prefix removal: {filename}")
+    base_name, _ = os.path.splitext(filename)
+    candidates = [
+        (base_name + ".webp", "image/webp"),
+        (base_name + ".png", "image/png"),
+        (base_name + ".jpg", "image/jpeg"),
+    ]
+    for name, mimetype in candidates:
+        path = os.path.join(THUMBNAILS_DIR, name)
+        if os.path.exists(path):
+            return send_from_directory(
+                os.path.dirname(path), os.path.basename(path), mimetype=mimetype
+            )
+    abort(404)
 
-    base_name, ext = os.path.splitext(filename)
-    webp_thumbnail = base_name + '.webp'
-    png_thumbnail = base_name + '.png'
-    jpg_thumbnail = base_name + '.jpg'
 
-    webp_path = os.path.join(THUMBNAILS_DIR, webp_thumbnail)
-    png_path = os.path.join(THUMBNAILS_DIR, png_thumbnail)
-    jpg_path = os.path.join(THUMBNAILS_DIR, jpg_thumbnail)
-
-    log.debug(f"WebP path: {webp_path}")
-    log.debug(f"PNG path: {png_path}")
-    log.debug(f"JPG path: {jpg_path}")
-
-    file_path = webp_path
-    if os.path.exists(file_path):
-        log.debug(f"Serving WebP thumbnail: {file_path}")
-        return send_thumbnail_with_correct_header(file_path, 'image/webp')
-    elif os.path.exists(png_path):
-        file_path = png_path
-        log.debug(f"Serving PNG thumbnail: {file_path}")
-        return send_thumbnail_with_correct_header(file_path, 'image/png')
-    elif os.path.exists(jpg_path):
-        file_path = jpg_path
-        log.debug(f"Serving JPG thumbnail: {file_path}")
-        return send_thumbnail_with_correct_header(file_path, 'image/jpeg')
-    else:
-        log.debug(f"Thumbnail not found for: {file_path}")
-        abort(404)  # Thumbnail not found
-
-def send_thumbnail_with_correct_header(file_path, mimetype):
-    try:
-        return send_from_directory(os.path.dirname(file_path), os.path.basename(file_path), mimetype=mimetype)
-    except FileNotFoundError:
-        log.error(f"File not found: {file_path}")
-        abort(404, description="File not found")
-    except Exception as e:
-        log.error(f"Error sending file: {file_path}, error: {str(e)}")
-        abort(500, description="Internal Server Error")
-
-@app.route('/doc_preview/<path:filename>')
+@app.route("/doc_preview/<path:filename>")
 def preview(filename):
-    if filename.endswith('.pdf'):
-        return render_template('pdf_preview.html', file_url=f"/preview/{filename}")
-    elif filename.endswith('.docx') or filename.lower().endswith('.doc'):
-        return render_template('doc_preview.html', file_url=f"/preview/{filename}")
-    elif filename.endswith('.xlsx') or filename.lower().endswith('.xls'):
-        return render_template('excel_preview.html', file_url=f"/preview/{filename}")
-    elif filename.lower().endswith('.csv'):
-        return render_template('csv_preview.html', file_url=f"/preview/{filename}")
-    else:
-        return "File type not supported", 400
+    lower = filename.lower()
+    if lower.endswith(".pdf"):
+        return render_template("pdf_preview.html", file_url=f"/preview/{filename}")
+    if lower.endswith(".docx") or lower.endswith(".doc"):
+        return render_template("doc_preview.html", file_url=f"/preview/{filename}")
+    if lower.endswith(".xlsx") or lower.endswith(".xls"):
+        return render_template("excel_preview.html", file_url=f"/preview/{filename}")
+    if lower.endswith(".csv"):
+        return render_template("csv_preview.html", file_url=f"/preview/{filename}")
+    return "File type not supported", 400
 
-@app.route('/preview/<path:file_path>', methods=['GET', 'HEAD'])
+
+@app.route("/preview/<path:file_path>", methods=["GET", "HEAD"])
 def preview_file(file_path):
     file_dir, file_name = os.path.split(file_path)
-    file_dir = "/" + file_dir
-    log.debug(f"Preview:{file_dir}:{file_name}")
-    if os.path.exists(f"{BASE_DIR}{file_dir}/{file_name}"):
-        return send_from_directory(BASE_DIR + file_dir, file_name)
-    else:
-        log.error(f"Error file not found: {file_dir}/{file_name}")
-        abort(404, description="File not found")
+    abs_dir = os.path.join(BASE_DIR, file_dir)
+    full = os.path.join(abs_dir, file_name)
+    if os.path.exists(full):
+        return send_from_directory(abs_dir, file_name)
+    log.error("preview file not found: %s", full)
+    abort(404, description="File not found")
 
-@app.route('/static/<path:filename>')
+
+@app.route("/static/<path:filename>")
 def serve_static(filename):
     return send_from_directory(STATIC_DIR, filename)
 
-# Configuration directories
-BASE_DIR = os.environ.get('BASE_DIR', '/win95/mcrlnsalg')
-STATIC_DIR = os.environ.get('STATIC_DIR', '/var/server/data/meta-server/static')
-THUMBNAILS_DIR = os.environ.get('THUMBNAILS_DIR', '/var/server/data/meta-server/thumbnails')
 
-if __name__ == '__main__':
-    WEB_IP = os.environ.get('WEB_IP', '0.0.0.0')
-    WEB_PORT = int(os.environ.get('WEB_PORT', '5000'))
-    log.debug(f"port={WEB_PORT}, host={WEB_IP}, debug=True, use_reloader=False")
-    app.run(port=WEB_PORT, host=WEB_IP, debug=True, use_reloader=False)
+if __name__ == "__main__":
+    web_ip = os.environ.get("WEB_IP", "0.0.0.0")
+    web_port = int(os.environ.get("WEB_PORT", "5000"))
+    log.debug("port=%d host=%s", web_port, web_ip)
+    app.run(port=web_port, host=web_ip, debug=True, use_reloader=False)


### PR DESCRIPTION
Adds the read side of the topic-graph store. common/retrieval.py is the transport-agnostic core (RetrievalService.search_chunks / topic_neighbors / ask) returning plain dataclasses; HTTP, MCP, and inference_server hooks are all expected to wrap it. server/server.py is ported off SQLite to common/db, and registers the HTTP adapter as a Flask blueprint at /search/semantic, /topics/<id>/neighbors, and /ask.

Notable changes:
  - search_chunks embeds the query via the QUERY role embedder and orders by pgvector cosine_distance, with optional file_type / category / inferred_category / topic_ids filters.
  - ask groups hits by topic before assembling the prompt so the chat_completion sees structured context, not a flat dump, and returns citations alongside the answer.
  - The file browser routes now query Document via common/db; folder aggregates (file_count, total_size) are computed on the fly with LIKE 'prefix/%' rather than a separate directory_metadata table.
  - The legacy in-process scan_queue + scan_thread are removed; that job belongs to scanner/index_worker now.

server Dockerfile installs from requirements.txt and copies the retrieval blueprint; compose mounts llm_providers/ into the server container so the embedder + LLM factories resolve.

